### PR TITLE
Patched darker areas for Application Launcher

### DIFF
--- a/plasma/desktoptheme/Harmony/widgets/plasmoidheading.svg
+++ b/plasma/desktoptheme/Harmony/widgets/plasmoidheading.svg
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg2"
+   viewBox="0 0 173 56.000004"
+   version="1.1"
+   sodipodi:docname="plasmoidheading.svg"
+   inkscape:version="1.1 (c4e8f9ed74, 2021-05-24)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata43">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs41" />
+  <sodipodi:namedview
+     pagecolor="#c8c8c8"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="742"
+     id="namedview39"
+     showgrid="false"
+     inkscape:zoom="4.9572898"
+     inkscape:cx="40.546349"
+     inkscape:cy="21.483513"
+     inkscape:window-x="1366"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:lockguides="true"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0" />
+  <style
+     id="current-color-scheme"
+     type="text/css" />
+  <path
+     id="hint-stretch-borders"
+     d="m-7-7h5v5h-5z"
+     opacity=".6"
+     style="fill:#14171f;fill-opacity:1;opacity:0.01" />
+  <path
+     id="header-center"
+     class="ColorScheme-Background"
+     d="M 19,12 H 51 V 44 H 19 Z"
+     style="color:#eff0f1;opacity:0;fill:#161a23;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     id="header-right"
+     class="ColorScheme-Background"
+     d="m 51,12 h 6 v 32 h -6 z"
+     style="color:#eff0f1;opacity:0;fill:#161a23;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     id="header-top"
+     class="ColorScheme-Background"
+     d="M 19,12.000004 V 6.0000026 h 32 v 6.0000014 z"
+     style="color:#eff0f1;opacity:0;fill:#161a23;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+  <g
+     id="header-bottom"
+     style="opacity:0">
+    <path
+       id="rect3152"
+       class="ColorScheme-Background"
+       d="m 51,44.000004 v 6 H 19 v -6 z"
+       style="color:#eff0f1;opacity:0.00100002;fill:#161a23;fill-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="rect3154"
+       class="ColorScheme-Text"
+       d="m 51,49 v 1 H 19 v -1 z"
+       style="color:#232629;opacity:0.00100002;fill:#020203;fill-opacity:1"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     id="header-left"
+     class="ColorScheme-Background"
+     d="M 19,44 H 13 V 12 h 6 z"
+     style="color:#eff0f1;opacity:0;fill:#161a23;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+  <g
+     id="header-bottomright"
+     style="opacity:0">
+    <path
+       id="path3176"
+       class="ColorScheme-Background"
+       d="m 57,44.000004 h -6 v 6 h 6 v -5 z"
+       style="color:#eff0f1;opacity:0.00100002;fill:#161a23;fill-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path3178"
+       class="ColorScheme-Text"
+       d="m 57,49 h -6 v 1 h 6 c 0,-1 -2e-5,0 0,-1 z"
+       style="color:#232629;opacity:0.00100002;fill:#020203;fill-opacity:1;fill-rule:evenodd"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="header-bottomleft"
+     style="opacity:0">
+    <path
+       id="path3182"
+       class="ColorScheme-Background"
+       d="m 19,49.999986 v -6 h -6 v 6 c 6,4e-5 0,0 4,0 h 1 z"
+       style="color:#eff0f1;opacity:0.00100002;fill:#161a23;fill-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path3184"
+       class="ColorScheme-Text"
+       d="m 19,50 v -1 h -4 l -2,-2e-5 v 1 L 15,50 h 1 z"
+       style="color:#232629;opacity:0.00100002;fill:#020203;fill-opacity:1;fill-rule:evenodd"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     id="header-topleft"
+     class="ColorScheme-Background"
+     d="m 16,6 c -2,0 -3,1 -3,3 v 3 h 6 V 6 h -1 1 z"
+     style="color:#eff0f1;opacity:0;fill:#161a23;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     id="header-topright"
+     class="ColorScheme-Background"
+     d="m 51,6 v 6 h 6 V 9 C 57,7 56,6 54,6 h -2 z"
+     style="color:#eff0f1;opacity:0;fill:#161a23;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     id="footer-center"
+     class="ColorScheme-Background"
+     d="M 67,44 H 99 V 12 H 67 Z"
+     style="color:#eff0f1;opacity:0;fill:#000000;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     id="footer-right"
+     class="ColorScheme-Background"
+     d="m 99,44 h 6 V 12 h -6 z"
+     style="color:#eff0f1;opacity:0;fill:#000000;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     id="footer-bottom"
+     class="ColorScheme-Background"
+     d="m 67,44.000004 v 6 h 32 v -6 z"
+     style="color:#eff0f1;opacity:0;fill:#000000;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+  <g
+     id="footer-top"
+     style="opacity:0">
+    <path
+       id="rect3152-0"
+       class="ColorScheme-Background"
+       d="M 99,12.000004 V 6.000003 H 67 v 6.000001 z"
+       style="color:#eff0f1;opacity:0.2;fill:#000000;fill-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="rect3154-9"
+       class="ColorScheme-Text"
+       d="m 99,7.0000038 v -1 H 67 v 1 z"
+       style="color:#232629;opacity:0.1;fill:#ffffff;fill-opacity:1"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     id="footer-left"
+     class="ColorScheme-Background"
+     d="m 67,12 h -6 v 32 h 6 z"
+     style="color:#eff0f1;opacity:0;fill:#000000;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+  <g
+     id="footer-topright"
+     style="opacity:0">
+    <path
+       id="path3176-6"
+       class="ColorScheme-Background"
+       d="M 105,12.000004 H 99 V 6.0000034 h 6 v 5.0000006 z"
+       style="color:#eff0f1;opacity:0.2;fill:#000000;fill-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path3178-2"
+       class="ColorScheme-Text"
+       d="M 105,7 H 99 V 6 h 6 c 0,1 -2e-5,0 0,1 z"
+       style="color:#232629;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="footer-topleft"
+     style="opacity:0">
+    <path
+       id="path3182-1"
+       class="ColorScheme-Background"
+       d="m 67,6 v 6 H 61 V 6 c 6,-4e-5 0,0 4,0 h 1 z"
+       style="color:#eff0f1;opacity:0.2;fill:#000000;fill-opacity:1;stroke-width:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path3184-8"
+       class="ColorScheme-Text"
+       d="m 67,5.9999838 v 1 h -4 l -2,2e-5 v -1 l 2,-2e-5 h 1 z"
+       style="color:#232629;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     id="footer-bottomleft"
+     class="ColorScheme-Background"
+     d="m 64,50 c -2,0 -3,-1 -3,-3 v -3 h 6 v 6 h -1 1 z"
+     style="color:#eff0f1;opacity:0;fill:#000000;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     id="footer-bottomright"
+     class="ColorScheme-Background"
+     d="m 99,50.000004 v -6 h 6 v 3 c 0,2 -1,3 -3,3 h -2 z"
+     style="color:#eff0f1;opacity:0;fill:#000000;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     id="hint-top-margin"
+     d="m 33,12 h 4 v 6 h -4 z"
+     style="fill:#4040c2;fill-opacity:1;stroke-width:0.99999994;opacity:0"
+     inkscape:connector-curvature="0" />
+  <path
+     id="hint-bottom-margin"
+     d="m 33,38 h 4 v 6 h -4 z"
+     style="fill:#4040c2;fill-opacity:1;opacity:0"
+     inkscape:connector-curvature="0" />
+  <path
+     id="hint-right-margin"
+     d="m 51,26 v 4 h -6 v -4 z"
+     style="fill:#4040c2;fill-opacity:1;opacity:0"
+     inkscape:connector-curvature="0" />
+  <path
+     id="hint-left-margin"
+     d="m 25,26 v 4 h -6 v -4 z"
+     style="fill:#4040c2;fill-opacity:1;stroke-width:1;opacity:0"
+     inkscape:connector-curvature="0" />
+</svg>


### PR DESCRIPTION
Added plasmoidheading.svg to remove both unintended darker areas that appear in the top and bottom of the Application Launcher that comes with Plasma 5.21